### PR TITLE
Scoped Configurations

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
     repo:    https://github.com/akutz/cobra
     vcs:     git
   - package: github.com/spf13/viper
-    ref:     c51e126d5b0408b2cf9a4ac4a19779d9cba08f3b
+    ref:     0f9e044d014b09b8fd2765cec3e88f13bec56bf9
     repo:    https://github.com/akutz/viper.git
     vcs:     git
   - package: github.com/go-yaml/yaml


### PR DESCRIPTION
This patch adds the new feature, Scoped Configurations. A scoped configuration is created by invoking the Scope function from a configuration instance. The return value is a Config instance itself, but all Get/Set/IsSet functions are prefixed with the scope that was provided upon the scoped instance's creation.
