### PR TITLE
YAML Validation

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,8 @@
 package: github.com/akutz/gofig
 import:
+  - package: github.com/stretchr/testify
+    ref:     master
+    vcs:     git
   - package: github.com/akutz/goof
     ref:     master
     repo:    https://github.com/akutz/goof

--- a/gofig.go
+++ b/gofig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/akutz/gotil"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -667,4 +668,24 @@ func isSecureKey(k string) bool {
 		"isSecure": ok,
 	}).Debug("isSecureKey")
 	return ok
+}
+
+// ValidateYAML verifies the YAML in the stream is valid.
+func ValidateYAML(r io.Reader) (map[interface{}]interface{}, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	m := map[interface{}]interface{}{}
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// ValidateYAMLString verifies the YAML string valid.
+func ValidateYAMLString(s string) (map[interface{}]interface{}, error) {
+	b := &bytes.Buffer{}
+	b.WriteString(s)
+	return ValidateYAML(b)
 }

--- a/gofig_test.go
+++ b/gofig_test.go
@@ -134,6 +134,50 @@ func assertConfigsEqual(c1 Config, c2 Config, t *testing.T) bool {
 	return true
 }
 
+func TestValidateYAML(t *testing.T) {
+
+	var err error
+
+	_, err = ValidateYAMLString(string(yamlConfig1))
+	assert.NoError(t, err)
+	_, err = ValidateYAMLString(string(yamlConfig2))
+	assert.NoError(t, err)
+
+	yamlString := `
+hello, world
+`
+	_, err = ValidateYAMLString(yamlString)
+	assert.Error(t, err)
+
+	yamlString = `
+	hi:
+		hello: you
+`
+	_, err = ValidateYAMLString(yamlString)
+	assert.Error(t, err)
+
+	yamlString = `
+hi:
+	hello: you
+`
+	_, err = ValidateYAMLString(yamlString)
+	assert.Error(t, err)
+
+	yamlString = `
+hi:
+    hello: you
+`
+	_, err = ValidateYAMLString(yamlString)
+	assert.NoError(t, err)
+
+	yamlString = `
+hi:
+  hello: you
+`
+	_, err = ValidateYAMLString(yamlString)
+	assert.NoError(t, err)
+}
+
 func TestAssertConfigDefaults(t *testing.T) {
 	newConfigDirs("TestAssertConfigDefaults", t)
 	wipeEnv()


### PR DESCRIPTION
This patch adds the functions `ValidateYAML` and `ValidateYAMLString` for validating YAML content prior to loading it into the configuration.
