### PR TITLE
Fixed Copy not Keeping Scope

### DIFF
--- a/gofig.go
+++ b/gofig.go
@@ -194,7 +194,11 @@ func (c *config) FlagSets() map[string]*flag.FlagSet {
 }
 
 func (c *scopedConfig) Copy() (Config, error) {
-	return c.c.Copy()
+	cc, err := c.c.Copy()
+	if err != nil {
+		return nil, err
+	}
+	return cc.Scope(c.scope), nil
 }
 func (c *config) Copy() (Config, error) {
 	newC := newConfig()

--- a/gofig_test.go
+++ b/gofig_test.go
@@ -509,6 +509,14 @@ func TestScope(t *testing.T) {
 	sc.Set("loggingEnabled", false)
 	assert.Equal(t, true, c.GetBool("loggingEnabled"))
 	assert.Equal(t, false, sc.GetBool("loggingEnabled"))
+
+	scc, err := sc.Copy()
+	assert.NoError(t, err)
+
+	assert.True(t, scc.IsSet("loglevel"))
+	assert.Equal(t, "error", scc.GetString("loglevel"))
+	assert.True(t, scc.IsSet("loggingEnabled"))
+	assert.Equal(t, false, scc.GetBool("loggingEnabled"))
 }
 
 func TestKeyNames(t *testing.T) {


### PR DESCRIPTION
This patch fixes a bug where a copied Config instance did not retain the scope of the original Config instance if a scope had been set.
