### PR TITLE
Scope with Prefix

### DIFF
--- a/gofig_test.go
+++ b/gofig_test.go
@@ -519,6 +519,22 @@ func TestScope(t *testing.T) {
 	assert.Equal(t, false, scc.GetBool("loggingEnabled"))
 }
 
+func TestScopeWithPrefix(t *testing.T) {
+	c := New()
+	c.Set("hello.world.everyone.out.here", true)
+	c.Set("hello.world.everyone.out.there", false)
+	c.Set("hello.world.planet2.everyone.out.there", true)
+	assert.True(t, c.GetBool("hello.world.everyone.out.here"))
+	assert.False(t, c.GetBool("hello.world.everyone.out.there"))
+
+	sc := c.Scope("hello.world.planet2")
+	scp := c.ScopeWithPrefix("hello.world.planet2", "hello.world")
+	assert.False(t, sc.GetBool("hello.world.everyone.out.there"))
+	assert.True(t, scp.GetBool("hello.world.everyone.out.there"))
+	assert.True(t, sc.GetBool("hello.world.everyone.out.here"))
+	assert.True(t, scp.GetBool("hello.world.everyone.out.here"))
+}
+
 func TestKeyNames(t *testing.T) {
 	r := NewRegistration("Test Reg 4")
 	r.Key(String, "", "", "", "testReg4.host")


### PR DESCRIPTION
This patch introduces a new function, `ScopeWithPrefix`.

ScopeWithPrefix returns a scoped view of the configuration like the
Scope function, but this variant allows the specification of a prefix.
The prefix enables the creation of a scoped configuration that does
not have the fully-qualified paths to the desired configuration keys.
For example, imagine the following YAML:

```
gofig:
  logging:
    enabled: true
  modules:
    admin:
      gofig:
        logging:
          enabled: true
```

To enable or disable logging the key is `gofig.logging.enabled`, but
the modules may require their own distinct values controlling logging
when using a scoped configuration via `Scope("gofig.modules.admin")`.
However, unless the complete key path of `gofig.logging.enabled` is
replicated under each named module, this isn't possible using the
standard key `gofig.logging.enabled`.

Using `ScopeWithPrefix("gofig.modules.admin", "gofig")` it is now
possible to enable the following YAML configuration so that the
scoped configuration can still use the `gofig.logging.enabled` key to
access the property value.

```
gofig:
  logging:
    enabled: true
  modules:
    admin:
      logging:
        enabled: true
```

The prefix value is simply removed from key requests such that an
attempt to access the key `gofig.logging.enabled` actually results
in the access attempt using the key `logging.enabled`.
