### PR TITLE
Use Primary Viper Repo, New YAML Fork/Branch

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,54 +1,81 @@
-hash: 61574715f6458ef0750d1ed1c99d1a28978177db9b6e60dc2977df5c2bf0823a
-updated: 2016-06-10T12:52:21.800917-05:00
+hash: faa3b51950e43534db73d053f4d3335baffb6eb21adff56f99ff180cf3e76309
+updated: 2016-09-08T10:26:32.608017565-05:00
 imports:
 - name: github.com/akutz/goof
   version: ea06624ca980bae80c1b615b8417723436d235ab
 - name: github.com/akutz/gotil
   version: 6fa2e80bd3ac40f15788cfc3d12ebba49a0add92
-- name: github.com/BurntSushi/toml
-  version: f0aeabca5a127c4078abb8c8d64298b147264b55
+- name: github.com/fsnotify/fsnotify
+  version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
 - name: github.com/go-yaml/yaml
-  version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
+  version: bc35f417f8a7664a73d46c9def2933417c03019f
   repo: https://github.com/akutz/yaml.git
+- name: github.com/hashicorp/hcl
+  version: 99df0eb941dd8ddbc83d3f3605a34f6a686ac85e
+  subpackages:
+  - hcl/ast
+  - hcl/parser
+  - hcl/token
+  - json/parser
+  - hcl/scanner
+  - hcl/strconv
+  - json/scanner
+  - json/token
 - name: github.com/kardianos/osext
-  version: 29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc
+  version: c2c54e542fb797ad986b31721e1baedf214ca413
   repo: https://github.com/kardianos/osext.git
   vcs: git
-- name: github.com/kr/pretty
-  version: add1dbc86daf0f983cd4a48ceb39deb95c729b67
-- name: github.com/kr/text
-  version: 7cafcd837844e784b526369c9bce262804aebc60
+- name: github.com/kr/fs
+  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: c265cfa48dda6474e208715ca93e987829f572f8
+  version: 0723e352fa358f9322c938cc2dadda874e9151a9
 - name: github.com/mitchellh/mapstructure
-  version: d2dd0262208475919e1a362f675cfc0e7c10e905
+  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+- name: github.com/pelletier/go-buffruneio
+  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
+- name: github.com/pelletier/go-toml
+  version: 31055c2ff0bb0c7f9095aec0d220aed21108121e
+- name: github.com/pkg/errors
+  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
+- name: github.com/pkg/sftp
+  version: 8197a2e580736b78d704be0fc47b2324c0591a32
 - name: github.com/Sirupsen/logrus
-  version: f3cfb454f4c209e6668c95216c4744b8fddb2356
+  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
+- name: github.com/spf13/afero
+  version: 20500e2abd0d1f4564a499e83d11d6c73cd58c27
+  subpackages:
+  - mem
+  - sftp
 - name: github.com/spf13/cast
-  version: 27b586b42e29bec072fe7379259cc719e1289da6
-- name: github.com/spf13/cobra
-  version: 363816bb13ce1710460c2345017fd35593cbf5ed
-  repo: https://github.com/akutz/cobra
+  version: e31f36ffc91a2ba9ddb72a4b6a607ff9b3d3cb63
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: b084184666e02084b8ccb9b704bf0d79c466eb1d
-  repo: https://github.com/spf13/pflag
+  version: 6fd2ff4ff8dfcdf5556fbdc0ac0284408274b1a7
 - name: github.com/spf13/viper
-  version: 317ec73d0d7507658ee3be15866b445d6d921848
-  repo: https://github.com/akutz/viper.git
+  version: 16990631d4aa7e38f73dbbbf37fa13e67c648531
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: d77da356e56a7428ad25149ca77381849a6a5232
+- name: golang.org/x/crypto
+  version: 9e590154d2353f3f5e1b24da7275686040dcf491
+  subpackages:
+  - ssh
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
 - name: golang.org/x/sys
-  version: b44883b474ffefa37335017174e397412b633a4f
+  version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
   subpackages:
   - unix
-- name: gopkg.in/fsnotify.v1
-  version: 30411dbcefb7a1da7e84f75530ad3abe4011b4f8
+- name: golang.org/x/text
+  version: 1e65e9bf72c307081cea196f47ef37aed17eb316
+  subpackages:
+  - transform
+  - unicode/norm
 - name: gopkg.in/yaml.v1
-  version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
+  version: bc35f417f8a7664a73d46c9def2933417c03019f
   repo: https://github.com/akutz/yaml.git
 - name: gopkg.in/yaml.v2
-  version: b4a9f8c4b84c6c4256d669c649837f1441e4b050
+  version: bc35f417f8a7664a73d46c9def2933417c03019f
   repo: https://github.com/akutz/yaml.git
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,24 +9,22 @@ import:
     version: v0.1.0
   - package: github.com/akutz/goof
     version: v0.1.0
-  - package: github.com/spf13/viper
-    ref:     support/rexray
-    repo:    https://github.com/akutz/viper.git
-  - package: github.com/spf13/pflag
-    ref:     b084184666e02084b8ccb9b704bf0d79c466eb1d
-    repo:    https://github.com/spf13/pflag
-  - package: github.com/spf13/cobra
-    ref:     363816bb13ce1710460c2345017fd35593cbf5ed
-    repo:    https://github.com/akutz/cobra
+
+
+################################################################################
+##                                  Go-YAML                                   ##
+################################################################################
+
   - package: github.com/go-yaml/yaml
-    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    ref:     feature/preserve-json-compat
     repo:    https://github.com/akutz/yaml.git
   - package: gopkg.in/yaml.v1
-    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    ref:     feature/preserve-json-compat
     repo:    https://github.com/akutz/yaml.git
   - package: gopkg.in/yaml.v2
-    ref:     b4a9f8c4b84c6c4256d669c649837f1441e4b050
+    ref:     feature/preserve-json-compat
     repo:    https://github.com/akutz/yaml.git
+
 
 ################################################################################
 ##                              Test Dependencies                             ##

--- a/gofig.go
+++ b/gofig.go
@@ -71,6 +71,10 @@ func init() {
 	secureKeys = map[string]*regKey{}
 	secureKeysRWL = &sync.RWMutex{}
 	loadEtcEnvironment()
+
+	// tell the yaml package to presrve JSON compatibility by using a string
+	// as the map key
+	yaml.PreserveJSONCodecCompatibility(true)
 }
 
 // Config is the interface that enables retrieving configuration information.


### PR DESCRIPTION
This patch updates GoFig to use the primary Viper repository, no longer depending upon the akutz fork for specific support. However, this patch also updates the YAML dependency from one forked branch to another. This new branch is linked to a [Go-YAML PR](https://github.com/go-yaml/yaml/pull/185), which enables the Go-YAML library to preserve JSON codec compatibility when unmarshaling data from YAML configuration files. Without this dependency, data unmarshaled with Go-YAML into Viper cannot then be marshaled to JSON and back again since by default Go-YAML uses map[interface{}]interface{} as its internal map type. Since the JSON codec does not support the interface{} type as a key, attempts to marshal data to JSON that was unmarshaled from YAML using the Go-YAML library fails.

This patch handles Issue #10. 
