### PR TITLE
Interfaces, Optional PFlag dependency, Travis Updaate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: go
 go:
-  - 1.5.1
+  - 1.6.3
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
   - go get github.com/Masterminds/glide
 install:
-  - glide up
+  - glide install
   - go get -d $(glide nv)
 script:
   - go install $(glide nv)

--- a/gofig_nopflag.go
+++ b/gofig_nopflag.go
@@ -1,0 +1,106 @@
+// +build !pflag
+
+package gofig
+
+import (
+	"io"
+
+	"github.com/spf13/viper"
+)
+
+// config contains the configuration information
+type config struct {
+	v                         *viper.Viper
+	disableEnvVarSubstitution bool
+}
+
+func newConfigObj() *config {
+	return &config{
+		v: viper.New(),
+		disableEnvVarSubstitution: DisableEnvVarSubstitution,
+	}
+}
+
+// Config is the interface that enables retrieving configuration information.
+// The variations of the Get function, the Set, IsSet, and Scope functions
+// all take an interface{} as their first parameter. However, the param must be
+// either a string or a fmt.Stringer, otherwise the function will panic.
+type Config interface {
+
+	// DisableEnvVarSubstitution is the same as the global flag,
+	// DisableEnvVarSubstitution.
+	DisableEnvVarSubstitution(disable bool)
+
+	// Parent gets the configuration's parent (if set).
+	Parent() Config
+
+	// Scope returns a scoped view of the configuration. The specified scope
+	// string will be used to prefix all property retrievals via the Get
+	// and Set functions. Please note that the other functions will still
+	// operate as they would for the non-scoped configuration instance. This
+	// includes the AllSettings and AllKeys functions as well; they are *not*
+	// scoped.
+	Scope(scope interface{}) Config
+
+	// GetScope returns the config's current scope (if any).
+	GetScope() string
+
+	// GetString returns the value associated with the key as a string
+	GetString(k interface{}) string
+
+	// GetBool returns the value associated with the key as a bool
+	GetBool(k interface{}) bool
+
+	// GetStringSlice returns the value associated with the key as a string
+	// slice.
+	GetStringSlice(k interface{}) []string
+
+	// GetInt returns the value associated with the key as an int
+	GetInt(k interface{}) int
+
+	// Get returns the value associated with the key
+	Get(k interface{}) interface{}
+
+	// Set sets an override value
+	Set(k interface{}, v interface{})
+
+	// IsSet returns a flag indicating whether or not a key is set.
+	IsSet(k interface{}) bool
+
+	// Copy creates a copy of this Config instance
+	Copy() (Config, error)
+
+	// ToJSON exports this Config instance to a JSON string
+	ToJSON() (string, error)
+
+	// ToJSONCompact exports this Config instance to a compact JSON string
+	ToJSONCompact() (string, error)
+
+	// MarshalJSON implements the encoding/json.Marshaller interface. It allows
+	// this type to provide its own marshalling routine.
+	MarshalJSON() ([]byte, error)
+
+	// ReadConfig reads a configuration stream into the current config instance
+	ReadConfig(in io.Reader) error
+
+	// ReadConfigFile reads a configuration files into the current config
+	// instance
+	ReadConfigFile(filePath string) error
+
+	// EnvVars returns an array of the initialized configuration keys as
+	// key=value strings where the key is configuration key's environment
+	// variable key and the value is the current value for that key.
+	EnvVars() []string
+
+	// AllKeys gets a list of all the keys present in this configuration.
+	AllKeys() []string
+
+	// AllSettings gets a map of this configuration's settings.
+	AllSettings() map[string]interface{}
+}
+
+func (c *config) processRegKeys(r ConfigRegistration) {
+	for k := range r.Keys() {
+		c.v.BindEnv(k.KeyName(), k.EnvVarName())
+	}
+}

--- a/gofig_nopflag_test.go
+++ b/gofig_nopflag_test.go
@@ -1,0 +1,23 @@
+// +build !pflag
+
+package gofig
+
+func testReg3() *configReg {
+	r := newRegistration("Mock Provider")
+	r.SetYAML(`mockProvider:
+    userName: admin
+    password: ""
+    insecure: true
+    useCerts: true
+    docker:
+        MinVolSize: 16
+        maxVolSize: 256
+`)
+	r.Key(String, "", "admin", "", "mockProvider.userName")
+	r.Key(String, "", "", "", "mockProvider.password")
+	r.Key(Bool, "", false, "", "mockProvider.useCerts")
+	r.Key(Int, "", 16, "", "mockProvider.docker.minVolSize")
+	r.Key(Bool, "i", true, "", "mockProvider.insecure")
+	r.Key(Int, "m", 256, "", "mockProvider.docker.maxVolSize")
+	return r
+}

--- a/gofig_pflag.go
+++ b/gofig_pflag.go
@@ -1,0 +1,166 @@
+// +build pflag
+
+package gofig
+
+import (
+	"fmt"
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// config contains the configuration information
+type config struct {
+	v                         *viper.Viper
+	flagSets                  map[string]*pflag.FlagSet
+	disableEnvVarSubstitution bool
+}
+
+func newConfigObj() *config {
+	return &config{
+		v:                         viper.New(),
+		flagSets:                  map[string]*pflag.FlagSet{},
+		disableEnvVarSubstitution: DisableEnvVarSubstitution,
+	}
+}
+
+// Config is the interface that enables retrieving configuration information.
+// The variations of the Get function, the Set, IsSet, and Scope functions
+// all take an interface{} as their first parameter. However, the param must be
+// either a string or a fmt.Stringer, otherwise the function will panic.
+type Config interface {
+
+	// DisableEnvVarSubstitution is the same as the global flag,
+	// DisableEnvVarSubstitution.
+	DisableEnvVarSubstitution(disable bool)
+
+	// Parent gets the configuration's parent (if set).
+	Parent() Config
+
+	// FlagSets gets the config's flag sets.
+	FlagSets() map[string]*pflag.FlagSet
+
+	// Scope returns a scoped view of the configuration. The specified scope
+	// string will be used to prefix all property retrievals via the Get
+	// and Set functions. Please note that the other functions will still
+	// operate as they would for the non-scoped configuration instance. This
+	// includes the AllSettings and AllKeys functions as well; they are *not*
+	// scoped.
+	Scope(scope interface{}) Config
+
+	// GetScope returns the config's current scope (if any).
+	GetScope() string
+
+	// GetString returns the value associated with the key as a string
+	GetString(k interface{}) string
+
+	// GetBool returns the value associated with the key as a bool
+	GetBool(k interface{}) bool
+
+	// GetStringSlice returns the value associated with the key as a string
+	// slice.
+	GetStringSlice(k interface{}) []string
+
+	// GetInt returns the value associated with the key as an int
+	GetInt(k interface{}) int
+
+	// Get returns the value associated with the key
+	Get(k interface{}) interface{}
+
+	// Set sets an override value
+	Set(k interface{}, v interface{})
+
+	// IsSet returns a flag indicating whether or not a key is set.
+	IsSet(k interface{}) bool
+
+	// Copy creates a copy of this Config instance
+	Copy() (Config, error)
+
+	// ToJSON exports this Config instance to a JSON string
+	ToJSON() (string, error)
+
+	// ToJSONCompact exports this Config instance to a compact JSON string
+	ToJSONCompact() (string, error)
+
+	// MarshalJSON implements the encoding/json.Marshaller interface. It allows
+	// this type to provide its own marshalling routine.
+	MarshalJSON() ([]byte, error)
+
+	// ReadConfig reads a configuration stream into the current config instance
+	ReadConfig(in io.Reader) error
+
+	// ReadConfigFile reads a configuration files into the current config
+	// instance
+	ReadConfigFile(filePath string) error
+
+	// EnvVars returns an array of the initialized configuration keys as
+	// key=value strings where the key is configuration key's environment
+	// variable key and the value is the current value for that key.
+	EnvVars() []string
+
+	// AllKeys gets a list of all the keys present in this configuration.
+	AllKeys() []string
+
+	// AllSettings gets a map of this configuration's settings.
+	AllSettings() map[string]interface{}
+}
+
+func (c *config) FlagSets() map[string]*pflag.FlagSet {
+	return c.flagSets
+}
+
+func (c *config) processRegKeys(r ConfigRegistration) {
+	fsn := fmt.Sprintf("%s Flags", r.Name())
+	fs, ok := c.flagSets[fsn]
+	if !ok {
+		fs = &pflag.FlagSet{}
+		c.flagSets[fsn] = fs
+	}
+
+	for k := range r.Keys() {
+
+		if fs.Lookup(k.FlagName()) != nil {
+			continue
+		}
+
+		evn := k.EnvVarName()
+
+		if LogRegKey {
+			log.WithFields(log.Fields{
+				"keyName":      k.KeyName(),
+				"keyType":      k.KeyType(),
+				"flagName":     k.FlagName(),
+				"envVar":       evn,
+				"defaultValue": k.DefaultValue(),
+				"usage":        k.Description(),
+			}).Debug("adding flag")
+		}
+
+		// bind the environment variable
+		c.v.BindEnv(k.KeyName(), evn)
+
+		if k.Short() == "" {
+			switch k.KeyType() {
+			case String, SecureString:
+				fs.String(k.FlagName(), k.DefaultValue().(string), k.Description())
+			case Int:
+				fs.Int(k.FlagName(), k.DefaultValue().(int), k.Description())
+			case Bool:
+				fs.Bool(k.FlagName(), k.DefaultValue().(bool), k.Description())
+			}
+		} else {
+			switch k.KeyType() {
+			case String, SecureString:
+				fs.StringP(k.FlagName(), k.Short(), k.DefaultValue().(string), k.Description())
+			case Int:
+				fs.IntP(k.FlagName(), k.Short(), k.DefaultValue().(int), k.Description())
+			case Bool:
+				fs.BoolP(k.FlagName(), k.Short(), k.DefaultValue().(bool), k.Description())
+			}
+		}
+
+		c.v.BindPFlag(k.KeyName(), fs.Lookup(k.FlagName()))
+	}
+}

--- a/gofig_pflag_test.go
+++ b/gofig_pflag_test.go
@@ -1,0 +1,20 @@
+// +build pflag
+
+package gofig
+
+func testReg3() *configReg {
+	r := newRegistration("Mock Provider")
+	r.SetYAML(`mockProvider:
+    userName: admin
+    useCerts: true
+    docker:
+        MinVolSize: 16
+`)
+	r.Key(String, "", "admin", "", "mockProvider.userName")
+	r.Key(String, "", "", "", "mockProvider.password")
+	r.Key(Bool, "", false, "", "mockProvider.useCerts")
+	r.Key(Int, "", 16, "", "mockProvider.docker.minVolSize")
+	r.Key(Bool, "i", true, "", "mockProvider.insecure")
+	r.Key(Int, "m", 256, "", "mockProvider.docker.maxVolSize")
+	return r
+}

--- a/gofig_reg.go
+++ b/gofig_reg.go
@@ -9,34 +9,58 @@ import (
 	"github.com/akutz/goof"
 )
 
-// Registration is used to register configuration information with the gofig
-// package.
-type Registration struct {
-	name string
-	yaml string
-	keys []*regKey
+// ConfigRegistration is an interface that describes a configuration
+// registration object.
+type ConfigRegistration interface {
+
+	// Name returns the name of the config registration.
+	Name() string
+
+	// YAML returns the registration's default yaml configuration.
+	YAML() string
+
+	// SetYAML sets the registration's default yaml configuration.
+	SetYAML(y string)
+
+	// Key adds a key to the registration.
+	//
+	// The first vararg argument is the yaml name of the key, using a '.' as
+	// the nested separator. If the second two arguments are omitted they will
+	// be generated from the first argument. The second argument is the explicit
+	// name of the flag bound to this key. The third argument is the explicit
+	// name of the environment variable bound to thie key.
+	Key(
+		keyType int,
+		short string,
+		defVal interface{},
+		description string,
+		keys ...interface{})
+
+	// Keys returns a channel on which a listener can receive the config
+	// registration's keys.
+	Keys() <-chan ConfigRegistrationKey
 }
 
-// KeyType is a config registration key type.
-type KeyType int
+// ConfigRegistrationKey is an interfact that describes a cofniguration
+// registration key object.
+type ConfigRegistrationKey interface {
+	KeyType() int
+	DefaultValue() interface{}
+	Short() string
+	Description() string
+	KeyName() string
+	FlagName() string
+	EnvVarName() string
+}
 
-const (
-	// String is a key with a string value
-	String KeyType = iota
+type configReg struct {
+	name string
+	yaml string
+	keys []ConfigRegistrationKey
+}
 
-	// Int is a key with an integer value
-	Int
-
-	// Bool is a key with a boolean value
-	Bool
-
-	// SecureString is a key with a string value that is not included when the
-	// configuration is marshaled to JSON.
-	SecureString
-)
-
-type regKey struct {
-	keyType    KeyType
+type configRegKey struct {
+	keyType    int
 	defVal     interface{}
 	short      string
 	desc       string
@@ -45,28 +69,50 @@ type regKey struct {
 	envVarName string
 }
 
+const (
+	// String is a key with a string value
+	String = iota // 0
+
+	// Int is a key with an integer value
+	Int // 1
+
+	// Bool is a key with a boolean value
+	Bool // 2
+
+	// SecureString is a key with a string value that is not included when the
+	// configuration is marshaled to JSON.
+	SecureString // 3
+)
+
 // NewRegistration creates a new registration with the given name.
-func NewRegistration(name string) *Registration {
-	return &Registration{
-		name: name,
-		keys: []*regKey{},
-	}
+func NewRegistration(name string) ConfigRegistration {
+	return newRegistration(name)
 }
 
-// Yaml sets the registration's default yaml configuration.
-func (r *Registration) Yaml(y string) {
-	r.yaml = y
+func newRegistration(name string) *configReg {
+	return &configReg{name: name, keys: []ConfigRegistrationKey{}}
 }
 
-// Key adds a key to the registration.
-//
-// The first vararg argument is the yaml name of the key, using a '.' as
-// the nested separator. If the second two arguments are omitted they will be
-// generated from the first argument. The second argument is the explicit name
-// of the flag bound to this key. The third argument is the explicit name of
-// the environment variable bound to thie key.
-func (r *Registration) Key(
-	keyType KeyType,
+func (r *configReg) Name() string {
+	return r.name
+}
+
+func (r *configReg) Keys() <-chan ConfigRegistrationKey {
+	c := make(chan ConfigRegistrationKey)
+	go func() {
+		for _, k := range r.keys {
+			c <- k
+		}
+		close(c)
+	}()
+	return c
+}
+
+func (r *configReg) YAML() string     { return r.yaml }
+func (r *configReg) SetYAML(y string) { r.yaml = y }
+
+func (r *configReg) Key(
+	keyType int,
 	short string,
 	defVal interface{},
 	description string,
@@ -77,7 +123,7 @@ func (r *Registration) Key(
 		panic(goof.New("keys is empty"))
 	}
 
-	rk := &regKey{
+	rk := &configRegKey{
 		keyType: keyType,
 		short:   short,
 		desc:    description,
@@ -125,7 +171,15 @@ func (r *Registration) Key(
 	r.keys = append(r.keys, rk)
 }
 
-func secureKey(k *regKey) {
+func (k *configRegKey) KeyType() int              { return k.keyType }
+func (k *configRegKey) DefaultValue() interface{} { return k.defVal }
+func (k *configRegKey) Short() string             { return k.short }
+func (k *configRegKey) Description() string       { return k.desc }
+func (k *configRegKey) KeyName() string           { return k.keyName }
+func (k *configRegKey) FlagName() string          { return k.flagName }
+func (k *configRegKey) EnvVarName() string        { return k.envVarName }
+
+func secureKey(k *configRegKey) {
 	secureKeysRWL.Lock()
 	defer secureKeysRWL.Unlock()
 	kn := strings.ToLower(k.keyName)


### PR DESCRIPTION
This patch updates Gofig so that the Gofig Registration work is now interface-based. Additionally, to use PFlag with Gofig the build tag pflag is now required, otherwise pflag is omitted and flag bindings are disabled.

This patch updates Travis to use Go 1.6.3. Additionally `glide install` is preferred over `glide up`.