### PR TITLE
PFlag Build Import Error Fix

### DIFF
--- a/gofig_pflag.go
+++ b/gofig_pflag.go
@@ -63,20 +63,20 @@ func (c *config) processRegKeys(r types.ConfigRegistration) {
 
 		if k.Short() == "" {
 			switch k.KeyType() {
-			case String, SecureString:
+			case types.String, types.SecureString:
 				fs.String(k.FlagName(), k.DefaultValue().(string), k.Description())
-			case Int:
+			case types.Int:
 				fs.Int(k.FlagName(), k.DefaultValue().(int), k.Description())
-			case Bool:
+			case types.Bool:
 				fs.Bool(k.FlagName(), k.DefaultValue().(bool), k.Description())
 			}
 		} else {
 			switch k.KeyType() {
-			case String, SecureString:
+			case types.String, types.SecureString:
 				fs.StringP(k.FlagName(), k.Short(), k.DefaultValue().(string), k.Description())
-			case Int:
+			case types.Int:
 				fs.IntP(k.FlagName(), k.Short(), k.DefaultValue().(int), k.Description())
-			case Bool:
+			case types.Bool:
 				fs.BoolP(k.FlagName(), k.Short(), k.DefaultValue().(bool), k.Description())
 			}
 		}

--- a/gofig_pflag_test.go
+++ b/gofig_pflag_test.go
@@ -2,6 +2,8 @@
 
 package gofig
 
+import "github.com/akutz/gofig/types"
+
 func testReg3() *configReg {
 	r := newRegistration("Mock Provider")
 	r.SetYAML(`mockProvider:
@@ -10,11 +12,11 @@ func testReg3() *configReg {
     docker:
         MinVolSize: 16
 `)
-	r.Key(String, "", "admin", "", "mockProvider.userName")
-	r.Key(String, "", "", "", "mockProvider.password")
-	r.Key(Bool, "", false, "", "mockProvider.useCerts")
-	r.Key(Int, "", 16, "", "mockProvider.docker.minVolSize")
-	r.Key(Bool, "i", true, "", "mockProvider.insecure")
-	r.Key(Int, "m", 256, "", "mockProvider.docker.maxVolSize")
+	r.Key(types.String, "", "admin", "", "mockProvider.userName")
+	r.Key(types.String, "", "", "", "mockProvider.password")
+	r.Key(types.Bool, "", false, "", "mockProvider.useCerts")
+	r.Key(types.Int, "", 16, "", "mockProvider.docker.minVolSize")
+	r.Key(types.Bool, "i", true, "", "mockProvider.insecure")
+	r.Key(types.Int, "m", 256, "", "mockProvider.docker.maxVolSize")
 	return r
 }


### PR DESCRIPTION
This patch fixes an error in the Gofig pflag files where the type constants were not being referenced correctly.